### PR TITLE
Add theme selection system with three distinct UI themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to this project will be documented in this file.
   - Recent sessions list
 - Session tracking on timer completion (saves to SQLite)
 - Navigation with stats (📊) and settings (⚙) buttons
+- **Glass Terminal design**: Modern UI with frosted glass, terminal colors, monospace font
+  - Circular progress ring visualization showing countdown
+  - Pulse glow animation on running timer
+  - Cyan/green color scheme with subtle gradients
+  - Enhanced button micro-interactions with ripple effects
+- Window dragging functionality (drag from anywhere on background)
+- Debug logging for session save operations
 
 ### Fixed
 - Timer running at wrong speed when window hidden (browser throttling)
@@ -25,6 +32,9 @@ All notable changes to this project will be documented in this file.
 - Removed unused Rust import warning
 - **Critical**: Session data not being saved (function signature mismatch)
 - **Critical**: Stats displaying incorrect data (property naming mismatch between interface and DB)
+- **Critical**: SQL operations blocked by missing Tauri permissions (added sql:allow-execute, sql:allow-select)
+- **Critical**: Window dragging blocked by missing permission (added core:window:allow-start-dragging)
+- Auto-start only working after breaks, not after work sessions
 - Auto-start race condition after break completion (replaced setTimeout with useEffect)
 - Settings max value inconsistency (longBreak now allows 60 min)
 - Stats showing zero/empty on error instead of error message
@@ -37,3 +47,6 @@ All notable changes to this project will be documented in this file.
 - Simplified Stats component (array map instead of duplicate sections)
 - Simplified Timer mode switcher (array map instead of 3 buttons)
 - Extracted date range query helper to reduce code duplication in db.ts
+- Window size increased to 380x280 (from 300x200) for better visual balance
+- Window made resizable for flexibility
+- All interactive elements excluded from drag region using -webkit-app-region

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tauri + React + Typescript</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap" rel="stylesheet">
   </head>
 
   <body>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,10 +9,13 @@
     "core:window:allow-show",
     "core:window:allow-set-focus",
     "core:window:allow-is-visible",
+    "core:window:allow-start-dragging",
     "core:event:default",
     "notification:default",
     "opener:default",
     "store:default",
-    "sql:default"
+    "sql:default",
+    "sql:allow-execute",
+    "sql:allow-select"
   ]
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,10 +14,10 @@
       {
         "label": "main",
         "title": "pomo",
-        "width": 300,
-        "height": 200,
+        "width": 380,
+        "height": 280,
         "visible": false,
-        "resizable": false,
+        "resizable": true,
         "decorations": false,
         "alwaysOnTop": true,
         "skipTaskbar": true

--- a/src/App.css
+++ b/src/App.css
@@ -5,30 +5,104 @@
 }
 
 .app {
-  padding: 16px;
+  padding: 20px;
   text-align: center;
-  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', sans-serif;
-  background: #1a1a1a;
-  color: #ffffff;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
+  background: linear-gradient(135deg, #0a0e17 0%, #1a1f2e 100%);
+  color: #e0e0e0;
   height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.app::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background:
+    radial-gradient(circle at 20% 50%, rgba(34, 211, 238, 0.03) 0%, transparent 50%),
+    radial-gradient(circle at 80% 80%, rgba(74, 222, 128, 0.03) 0%, transparent 50%);
+  pointer-events: none;
+}
+
+.timer {
+  position: relative;
+  z-index: 1;
+}
+
+/* Progress Ring */
+.progress-ring {
+  position: relative;
+  width: 280px;
+  height: 280px;
+  margin: 0 auto 24px;
+}
+
+.progress-ring-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  transform: scaleX(-1); /* Flip horizontally to make it go clockwise */
+}
+
+.progress-ring-bg {
+  stroke: rgba(255, 255, 255, 0.05);
+  transition: stroke 0.3s;
+}
+
+.progress-ring-circle {
+  stroke: #22d3ee;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.3s linear, stroke 0.3s;
+  filter: drop-shadow(0 0 8px rgba(34, 211, 238, 0.4));
+}
+
+.progress-ring-circle.running {
+  animation: pulse-glow 2s ease-in-out infinite;
+}
+
+@keyframes pulse-glow {
+  0%, 100% {
+    filter: drop-shadow(0 0 8px rgba(34, 211, 238, 0.4));
+  }
+  50% {
+    filter: drop-shadow(0 0 16px rgba(34, 211, 238, 0.6));
+  }
+}
+
+.timer-content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
 }
 
 .timer .mode {
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 1px;
-  opacity: 0.6;
-  margin-bottom: 4px;
+  letter-spacing: 2px;
+  color: #4ade80;
+  opacity: 0.8;
+  margin-bottom: 12px;
+  font-weight: 500;
 }
 
 .timer .time {
-  font-size: 56px;
-  font-weight: 200;
+  font-size: 64px;
+  font-weight: 300;
   font-variant-numeric: tabular-nums;
-  margin-bottom: 16px;
+  color: #22d3ee;
+  text-shadow: 0 0 20px rgba(34, 211, 238, 0.3);
+  letter-spacing: -2px;
 }
 
 .timer .controls {
@@ -38,19 +112,58 @@
   margin-bottom: 16px;
 }
 
+/* Exclude interactive elements from drag region */
+button,
+input,
+a,
+select,
+textarea {
+  -webkit-app-region: no-drag;
+}
+
 .timer button {
-  padding: 8px 20px;
-  border: none;
-  border-radius: 6px;
-  background: #333;
-  color: #fff;
-  font-size: 14px;
+  padding: 10px 24px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  color: #e0e0e0;
+  font-size: 13px;
+  font-family: inherit;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+
+.timer button::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-radius: 50%;
+  background: rgba(34, 211, 238, 0.2);
+  transform: translate(-50%, -50%);
+  transition: width 0.6s, height 0.6s;
+}
+
+.timer button:hover::before {
+  width: 300px;
+  height: 300px;
 }
 
 .timer button:hover {
-  background: #444;
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(34, 211, 238, 0.3);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(34, 211, 238, 0.15);
+}
+
+.timer button:active {
+  transform: translateY(0) scale(0.98);
 }
 
 .timer .mode-switcher {
@@ -60,21 +173,31 @@
 }
 
 .timer .mode-switcher button {
-  padding: 4px 12px;
-  font-size: 11px;
-  background: #222;
+  padding: 6px 14px;
+  font-size: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.05);
+  letter-spacing: 1px;
+}
+
+.timer .mode-switcher button::before {
+  background: rgba(74, 222, 128, 0.1);
 }
 
 .timer .mode-switcher button.active {
-  background: #0066ff;
+  background: rgba(74, 222, 128, 0.15);
+  border-color: rgba(74, 222, 128, 0.3);
+  color: #4ade80;
+  box-shadow: 0 0 20px rgba(74, 222, 128, 0.1);
 }
 
 .timer .mode-switcher button:hover {
-  background: #333;
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .timer .mode-switcher button.active:hover {
-  background: #0055dd;
+  background: rgba(74, 222, 128, 0.2);
+  box-shadow: 0 4px 12px rgba(74, 222, 128, 0.2);
 }
 
 /* Navigation buttons */
@@ -87,18 +210,28 @@
 }
 
 .nav-btn {
-  background: transparent;
-  border: none;
-  color: #666;
-  font-size: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  color: #888;
+  font-size: 14px;
   cursor: pointer;
-  padding: 4px;
+  padding: 6px 8px;
   line-height: 1;
-  transition: color 0.15s;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  backdrop-filter: blur(10px);
 }
 
 .nav-btn:hover {
-  color: #fff;
+  color: #22d3ee;
+  background: rgba(34, 211, 238, 0.1);
+  border-color: rgba(34, 211, 238, 0.2);
+  transform: translateY(-1px) scale(1.05);
+  box-shadow: 0 4px 8px rgba(34, 211, 238, 0.15);
+}
+
+.nav-btn:active {
+  transform: translateY(0) scale(1);
 }
 
 /* Settings panel */

--- a/src/App.css
+++ b/src/App.css
@@ -4,12 +4,68 @@
   box-sizing: border-box;
 }
 
+/* Theme transitions */
+*:not(svg):not(svg *) {
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+/* Glass Terminal Theme (Default) */
+[data-theme="glass"] {
+  --color-primary: #22d3ee;
+  --color-secondary: #4ade80;
+  --color-bg-start: #0a0e17;
+  --color-bg-end: #1a1f2e;
+  --color-text: #e0e0e0;
+  --color-text-dim: #888;
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-bg-surface: rgba(255, 255, 255, 0.05);
+  --glow-primary: rgba(34, 211, 238, 0.4);
+  --glow-secondary: rgba(74, 222, 128, 0.4);
+  --font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
+  --border-radius: 8px;
+  --shadow: 0 4px 12px rgba(34, 211, 238, 0.15);
+}
+
+/* Analog Warmth Theme */
+[data-theme="warmth"] {
+  --color-primary: #ff8c42;
+  --color-secondary: #ff6b6b;
+  --color-bg-start: #fef6e4;
+  --color-bg-end: #f3d2c1;
+  --color-text: #2b2b2b;
+  --color-text-dim: #8b7355;
+  --color-border: rgba(139, 115, 85, 0.3);
+  --color-bg-surface: rgba(255, 255, 255, 0.5);
+  --glow-primary: rgba(255, 140, 66, 0.3);
+  --glow-secondary: rgba(255, 107, 107, 0.3);
+  --font-family: 'Caveat', cursive;
+  --border-radius: 16px;
+  --shadow: 0 6px 20px rgba(139, 115, 85, 0.2);
+}
+
+/* Brutalist Focus Theme */
+[data-theme="brutalist"] {
+  --color-primary: #ffffff;
+  --color-secondary: #ff0000;
+  --color-bg-start: #000000;
+  --color-bg-end: #000000;
+  --color-text: #ffffff;
+  --color-text-dim: #cccccc;
+  --color-border: #ffffff;
+  --color-bg-surface: #1a1a1a;
+  --glow-primary: transparent;
+  --glow-secondary: transparent;
+  --font-family: Impact, 'Arial Black', 'Franklin Gothic Bold', sans-serif;
+  --border-radius: 0px;
+  --shadow: none;
+}
+
 .app {
   padding: 20px;
   text-align: center;
-  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
-  background: linear-gradient(135deg, #0a0e17 0%, #1a1f2e 100%);
-  color: #e0e0e0;
+  font-family: var(--font-family);
+  background: linear-gradient(135deg, var(--color-bg-start) 0%, var(--color-bg-end) 100%);
+  color: var(--color-text);
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -54,15 +110,15 @@
 }
 
 .progress-ring-bg {
-  stroke: rgba(255, 255, 255, 0.05);
+  stroke: var(--color-border);
   transition: stroke 0.3s;
 }
 
 .progress-ring-circle {
-  stroke: #22d3ee;
+  stroke: var(--color-primary);
   stroke-linecap: round;
   transition: stroke-dashoffset 0.3s linear, stroke 0.3s;
-  filter: drop-shadow(0 0 8px rgba(34, 211, 238, 0.4));
+  filter: drop-shadow(0 0 8px var(--glow-primary));
 }
 
 .progress-ring-circle.running {
@@ -71,10 +127,10 @@
 
 @keyframes pulse-glow {
   0%, 100% {
-    filter: drop-shadow(0 0 8px rgba(34, 211, 238, 0.4));
+    filter: drop-shadow(0 0 8px var(--glow-primary));
   }
   50% {
-    filter: drop-shadow(0 0 16px rgba(34, 211, 238, 0.6));
+    filter: drop-shadow(0 0 16px var(--glow-primary));
   }
 }
 
@@ -90,7 +146,7 @@
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 2px;
-  color: #4ade80;
+  color: var(--color-secondary);
   opacity: 0.8;
   margin-bottom: 12px;
   font-weight: 500;
@@ -100,8 +156,8 @@
   font-size: 64px;
   font-weight: 300;
   font-variant-numeric: tabular-nums;
-  color: #22d3ee;
-  text-shadow: 0 0 20px rgba(34, 211, 238, 0.3);
+  color: var(--color-primary);
+  text-shadow: 0 0 20px var(--glow-primary);
   letter-spacing: -2px;
 }
 
@@ -123,12 +179,12 @@ textarea {
 
 .timer button {
   padding: 10px 24px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  background: var(--color-bg-surface);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  color: #e0e0e0;
+  color: var(--color-text);
   font-size: 13px;
   font-family: inherit;
   cursor: pointer;
@@ -145,7 +201,7 @@ textarea {
   width: 0;
   height: 0;
   border-radius: 50%;
-  background: rgba(34, 211, 238, 0.2);
+  background: var(--glow-primary);
   transform: translate(-50%, -50%);
   transition: width 0.6s, height 0.6s;
 }
@@ -156,10 +212,10 @@ textarea {
 }
 
 .timer button:hover {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(34, 211, 238, 0.3);
+  background: var(--color-bg-surface);
+  border-color: var(--color-primary);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(34, 211, 238, 0.15);
+  box-shadow: var(--shadow);
 }
 
 .timer button:active {
@@ -175,29 +231,29 @@ textarea {
 .timer .mode-switcher button {
   padding: 6px 14px;
   font-size: 10px;
-  background: rgba(255, 255, 255, 0.03);
-  border-color: rgba(255, 255, 255, 0.05);
+  background: var(--color-bg-surface);
+  border-color: var(--color-border);
   letter-spacing: 1px;
 }
 
 .timer .mode-switcher button::before {
-  background: rgba(74, 222, 128, 0.1);
+  background: var(--glow-secondary);
 }
 
 .timer .mode-switcher button.active {
-  background: rgba(74, 222, 128, 0.15);
-  border-color: rgba(74, 222, 128, 0.3);
-  color: #4ade80;
-  box-shadow: 0 0 20px rgba(74, 222, 128, 0.1);
+  background: var(--glow-secondary);
+  border-color: var(--color-secondary);
+  color: var(--color-secondary);
+  box-shadow: var(--shadow);
 }
 
 .timer .mode-switcher button:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--color-bg-surface);
 }
 
 .timer .mode-switcher button.active:hover {
-  background: rgba(74, 222, 128, 0.2);
-  box-shadow: 0 4px 12px rgba(74, 222, 128, 0.2);
+  background: var(--glow-secondary);
+  box-shadow: var(--shadow);
 }
 
 /* Navigation buttons */
@@ -210,10 +266,10 @@ textarea {
 }
 
 .nav-btn {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 6px;
-  color: #888;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  color: var(--color-text-dim);
   font-size: 14px;
   cursor: pointer;
   padding: 6px 8px;
@@ -223,11 +279,11 @@ textarea {
 }
 
 .nav-btn:hover {
-  color: #22d3ee;
-  background: rgba(34, 211, 238, 0.1);
-  border-color: rgba(34, 211, 238, 0.2);
+  color: var(--color-primary);
+  background: var(--glow-primary);
+  border-color: var(--color-primary);
   transform: translateY(-1px) scale(1.05);
-  box-shadow: 0 4px 8px rgba(34, 211, 238, 0.15);
+  box-shadow: var(--shadow);
 }
 
 .nav-btn:active {
@@ -258,7 +314,7 @@ textarea {
 .close-btn {
   background: transparent;
   border: none;
-  color: #666;
+  color: var(--color-text-dim);
   font-size: 20px;
   cursor: pointer;
   padding: 0;
@@ -266,7 +322,7 @@ textarea {
 }
 
 .close-btn:hover {
-  color: #fff;
+  color: var(--color-text);
 }
 
 .settings-section {
@@ -295,34 +351,34 @@ textarea {
 .setting-row input {
   width: 60px;
   padding: 6px 8px;
-  border: 1px solid #333;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  background: #222;
-  color: #fff;
+  background: var(--color-bg-surface);
+  color: var(--color-text);
   font-size: 14px;
   text-align: center;
 }
 
 .setting-row input:focus {
   outline: none;
-  border-color: #0066ff;
+  border-color: var(--color-primary);
 }
 
 .reset-btn {
   width: 100%;
   padding: 8px;
-  border: 1px solid #333;
-  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
   background: transparent;
-  color: #888;
+  color: var(--color-text-dim);
   font-size: 12px;
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .reset-btn:hover {
-  border-color: #555;
-  color: #fff;
+  border-color: var(--color-border);
+  color: var(--color-text);
 }
 
 /* Stats panel */
@@ -367,7 +423,7 @@ textarea {
 
 .stat-label {
   font-size: 14px;
-  color: #888;
+  color: var(--color-text-dim);
 }
 
 .stat-value {
@@ -378,13 +434,13 @@ textarea {
 
 .loading {
   text-align: center;
-  color: #666;
+  color: var(--color-text-dim);
   padding: 20px;
 }
 
 .error {
   text-align: center;
-  color: #ff6b6b;
+  color: var(--color-secondary);
   padding: 20px;
   font-size: 14px;
 }
@@ -400,16 +456,61 @@ textarea {
   justify-content: space-between;
   align-items: center;
   padding: 8px;
-  background: #222;
+  background: var(--color-bg-surface);
   border-radius: 4px;
   font-size: 13px;
 }
 
 .session-mode {
-  color: #aaa;
+  color: var(--color-text-dim);
 }
 
 .session-time {
-  color: #666;
+  color: var(--color-text-dim);
   font-variant-numeric: tabular-nums;
+}
+
+/* Theme selector */
+.theme-option {
+  margin-bottom: 12px;
+}
+
+.theme-option label {
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.theme-option label:hover {
+  background: var(--color-bg-surface);
+  border-color: var(--color-primary);
+}
+
+.theme-option input[type="radio"] {
+  margin-right: 12px;
+  accent-color: var(--color-primary);
+}
+
+.theme-option input[type="radio"]:checked + .theme-info {
+  color: var(--color-primary);
+}
+
+.theme-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.theme-label {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.theme-description {
+  font-size: 11px;
+  color: var(--color-text-dim);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ type View = 'timer' | 'settings' | 'stats';
 
 function App() {
   const [view, setView] = useState<View>('timer');
-  const { loadSettings, isLoaded } = useSettingsStore();
+  const { loadSettings, isLoaded, theme } = useSettingsStore();
   const syncWithSettings = useTimerStore((s) => s.syncWithSettings);
 
   // Load settings on mount
@@ -40,22 +40,22 @@ function App() {
   }
 
   return (
-    <div className="app" data-tauri-drag-region>
+    <div className="app" data-tauri-drag-region data-theme={theme}>
+      {/* Timer always mounted to keep countdown running */}
+      <div style={{ display: view === 'timer' ? 'contents' : 'none' }}>
+        <Timer />
+        <div className="nav-buttons">
+          <button className="nav-btn" onClick={() => setView('stats')}>
+            📊
+          </button>
+          <button className="nav-btn" onClick={() => setView('settings')}>
+            ⚙
+          </button>
+        </div>
+      </div>
+
       {view === 'settings' && <Settings onClose={() => setView('timer')} />}
       {view === 'stats' && <Stats onClose={() => setView('timer')} />}
-      {view === 'timer' && (
-        <>
-          <Timer />
-          <div className="nav-buttons">
-            <button className="nav-btn" onClick={() => setView('stats')}>
-              📊
-            </button>
-            <button className="nav-btn" onClick={() => setView('settings')}>
-              ⚙
-            </button>
-          </div>
-        </>
-      )}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ function App() {
   }
 
   return (
-    <div className="app">
+    <div className="app" data-tauri-drag-region>
       {view === 'settings' && <Settings onClose={() => setView('timer')} />}
       {view === 'stats' && <Stats onClose={() => setView('timer')} />}
       {view === 'timer' && (

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { useSettingsStore } from '../stores/settingsStore';
+import { useSettingsStore, Theme } from '../stores/settingsStore';
 import { useTimerStore } from '../stores/timerStore';
 
 interface Props {
@@ -6,13 +6,19 @@ interface Props {
 }
 
 export function Settings({ onClose }: Props) {
-    const { durations, setDuration, resetToDefaults } = useSettingsStore();
+    const { durations, theme, setDuration, setTheme, resetToDefaults } = useSettingsStore();
     const syncWithSettings = useTimerStore((s) => s.syncWithSettings);
 
     const durationFields = [
         { mode: 'work' as const, label: 'Work', max: 60 },
         { mode: 'shortBreak' as const, label: 'Short Break', max: 30 },
         { mode: 'longBreak' as const, label: 'Long Break', max: 60 },
+    ];
+
+    const themes: { value: Theme; label: string; description: string }[] = [
+        { value: 'glass', label: 'Glass Terminal', description: 'Frosted glass, cyan & green' },
+        { value: 'warmth', label: 'Analog Warmth', description: 'Cozy, handwritten feel' },
+        { value: 'brutalist', label: 'Brutalist Focus', description: 'High contrast, minimal' },
     ];
 
     const handleChange = (mode: 'work' | 'shortBreak' | 'longBreak', value: string) => {
@@ -33,6 +39,27 @@ export function Settings({ onClose }: Props) {
             <div className="settings-header">
                 <h2>Settings</h2>
                 <button className="close-btn" onClick={onClose}>×</button>
+            </div>
+
+            <div className="settings-section">
+                <h3>Appearance</h3>
+                {themes.map(({ value, label, description }) => (
+                    <div key={value} className="theme-option">
+                        <label>
+                            <input
+                                type="radio"
+                                name="theme"
+                                value={value}
+                                checked={theme === value}
+                                onChange={() => setTheme(value)}
+                            />
+                            <div className="theme-info">
+                                <span className="theme-label">{label}</span>
+                                <span className="theme-description">{description}</span>
+                            </div>
+                        </label>
+                    </div>
+                ))}
             </div>
 
             <div className="settings-section">

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getTodaySessions, getWeekSessions, Session } from '../lib/db';
+import { getTodaySessions, getWeekSessions, getAllTimeSessions, Session } from '../lib/db';
 
 interface Props {
     onClose: () => void;
@@ -8,16 +8,19 @@ interface Props {
 export function Stats({ onClose }: Props) {
     const [todaySessions, setTodaySessions] = useState<Session[]>([]);
     const [weekSessions, setWeekSessions] = useState<Session[]>([]);
+    const [allTimeSessions, setAllTimeSessions] = useState<Session[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
         Promise.all([
             getTodaySessions(),
-            getWeekSessions()
-        ]).then(([today, week]) => {
+            getWeekSessions(),
+            getAllTimeSessions()
+        ]).then(([today, week, allTime]) => {
             setTodaySessions(today);
             setWeekSessions(week);
+            setAllTimeSessions(allTime);
             setLoading(false);
         }).catch(err => {
             console.error('Failed to load stats:', err);
@@ -40,6 +43,7 @@ export function Stats({ onClose }: Props) {
 
     const todayStats = calculateStats(todaySessions);
     const weekStats = calculateStats(weekSessions);
+    const allTimeStats = calculateStats(allTimeSessions);
 
     if (loading) {
         return (
@@ -68,6 +72,7 @@ export function Stats({ onClose }: Props) {
     const statSections = [
         { title: 'Today', stats: todayStats },
         { title: 'This Week', stats: weekStats },
+        { title: 'All Time', stats: allTimeStats },
     ];
 
     return (

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -8,7 +8,12 @@ import { useSettingsStore } from '../stores/settingsStore';
 
 export function Timer() {
     const { mode, status, remainingSeconds, start, pause, reset, setMode } = useTimerStore();
+    const { durations } = useSettingsStore();
     const [shouldAutoStart, setShouldAutoStart] = useState(false);
+
+    // Calculate progress percentage for visual ring
+    const totalSeconds = durations[mode] * 60;
+    const progress = (remainingSeconds / totalSeconds) * 100;
 
     // Format seconds as MM:SS
     const formatTime = (seconds: number): string => {
@@ -61,6 +66,8 @@ export function Timer() {
     // Handle timer completion
     useEffect(() => {
         if (remainingSeconds === 0 && status === 'running') {
+            console.log('[Timer] Completing session:', { mode, durations: useSettingsStore.getState().durations });
+
             // Play sound based on completed mode
             if (mode === 'work') {
                 playWorkCompleteSound();
@@ -73,11 +80,15 @@ export function Timer() {
 
             // Save session to database
             const { durations } = useSettingsStore.getState();
-            saveSession(mode, durations[mode] * 60).catch(console.error);
+            console.log('[Timer] Saving session:', mode, durations[mode] * 60);
+            saveSession(mode, durations[mode] * 60)
+                .then(() => console.log('[Timer] Session saved successfully'))
+                .catch(err => console.error('[Timer] Failed to save session:', err));
 
-            // Auto-switch modes
+            // Auto-switch modes and trigger auto-start
             if (mode === 'work') {
                 setMode('shortBreak');
+                setShouldAutoStart(true);
             } else {
                 setMode('work');
                 setShouldAutoStart(true);
@@ -85,13 +96,13 @@ export function Timer() {
         }
     }, [remainingSeconds, status, mode, setMode]);
 
-    // Auto-start work after mode switches to work (reliable, no race condition)
+    // Auto-start next session after mode switch (reliable, no race condition)
     useEffect(() => {
-        if (shouldAutoStart && mode === 'work' && status === 'idle') {
+        if (shouldAutoStart && status === 'idle') {
             start();
             setShouldAutoStart(false);
         }
-    }, [shouldAutoStart, mode, status, start]);
+    }, [shouldAutoStart, status, start]);
 
     const modeLabels = {
         work: 'Focus',
@@ -107,8 +118,35 @@ export function Timer() {
 
     return (
         <div className="timer">
-            <div className="mode">{modeLabels[mode]}</div>
-            <div className="time">{formatTime(remainingSeconds)}</div>
+            <div className="progress-ring">
+                <svg className="progress-ring-svg" viewBox="0 0 200 200">
+                    {/* Background circle */}
+                    <circle
+                        className="progress-ring-bg"
+                        cx="100"
+                        cy="100"
+                        r="85"
+                        fill="none"
+                        strokeWidth="4"
+                    />
+                    {/* Progress circle */}
+                    <circle
+                        className={`progress-ring-circle ${status === 'running' ? 'running' : ''}`}
+                        cx="100"
+                        cy="100"
+                        r="85"
+                        fill="none"
+                        strokeWidth="4"
+                        strokeDasharray={`${2 * Math.PI * 85}`}
+                        strokeDashoffset={`${2 * Math.PI * 85 * (1 - progress / 100)}`}
+                        transform="rotate(-90 100 100)"
+                    />
+                </svg>
+                <div className="timer-content">
+                    <div className="mode">{modeLabels[mode]}</div>
+                    <div className="time">{formatTime(remainingSeconds)}</div>
+                </div>
+            </div>
 
             <div className="controls">
                 {status === 'running' ? (

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -73,6 +73,19 @@ export const getWeekSessions = () => getSessionsSince(7, 'week\'s');
 export const getMonthSessions = () => getSessionsSince(30, 'month\'s');
 export const getYearSessions = () => getSessionsSince(365, 'year\'s');
 
+export async function getAllTimeSessions(): Promise<Session[]> {
+  try {
+    const database = await getDb();
+    const sessions = await database.select<Session[]>(
+      `SELECT id, mode, duration_seconds AS durationSeconds, completed_at AS completedAt, completed FROM sessions ORDER BY completed_at DESC`
+    );
+    return sessions;
+  } catch (error) {
+    console.error('Failed to load all-time sessions:', error);
+    throw new Error('Could not load all-time statistics.');
+  }
+}
+
 export async function getTotalSessionDuration(): Promise<number> {
   const database = await getDb();
   const result = await database.select<Array<{ sum: number | null }>>('SELECT SUM(duration_seconds) as sum FROM sessions');


### PR DESCRIPTION
## Summary
Implements a user-selectable theme system with three distinct visual styles, smooth transitions, and persistence across app restarts.

### Themes
- **Glass Terminal** (default): Frosted glass aesthetic, cyan/green colors, monospace font
- **Analog Warmth**: Cozy handwritten feel (Caveat font), warm amber/coral colors, softer edges
- **Brutalist Focus**: High contrast black/white, bold sans-serif (Impact), minimal decoration

### Technical Details
- CSS custom properties for performance and zero runtime overhead
- Smooth 0.3s transitions between themes (excluding SVG elements)
- Theme preference persists via Tauri plugin-store
- Theme selector UI in Settings panel with radio buttons and descriptions

### Additional Improvements
- Added All Time stats section to Stats view
- Fixed timer continuity (timer now continues running when viewing Stats/Settings)
- All UI components (progress ring, buttons, panels) adapt to selected theme

### Test Plan
- [x] All three themes display correctly
- [x] Smooth transitions between themes
- [x] Theme persists across app restarts
- [x] Theme selector accessible and functional
- [x] All UI components styled correctly in each theme
- [x] Timer continues running when switching views

Closes #9